### PR TITLE
Improvement: avoid downgrades by syncing configmaps faster and waiting when they change

### DIFF
--- a/internal/controller/typesensecluster_condition_types.go
+++ b/internal/controller/typesensecluster_condition_types.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ const (
 )
 
 func (r *TypesenseClusterReconciler) initConditions(ctx context.Context, ts *tsv1alpha1.TypesenseCluster) error {
-	if ts.Status.Conditions == nil || len(ts.Status.Conditions) == 0 {
+	if len(ts.Status.Conditions) == 0 {
 		if err := r.patchStatus(ctx, ts, func(status *tsv1alpha1.TypesenseClusterStatus) {
 			meta.SetStatusCondition(&ts.Status.Conditions, metav1.Condition{Type: ConditionTypeReady, Status: metav1.ConditionUnknown, Reason: ConditionReasonReconciliationInProgress, Message: InitReconciliationMessage})
 			status.Phase = "Bootstrapping"

--- a/internal/controller/typesensecluster_configmap.go
+++ b/internal/controller/typesensecluster_configmap.go
@@ -109,6 +109,9 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 	}
 
 	nodes, err := r.getNodes(ctx, ts, *replicas, false)
+	if err != nil {
+		return nil, 0, false, err
+	}
 	fallback, err := r.getNodes(ctx, ts, *replicas, true)
 	if err != nil {
 		return nil, 0, false, err

--- a/internal/controller/typesensecluster_configmap.go
+++ b/internal/controller/typesensecluster_configmap.go
@@ -3,53 +3,55 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
-func (r *TypesenseClusterReconciler) ReconcileConfigMap(ctx context.Context, ts tsv1alpha1.TypesenseCluster) (updated *bool, err error) {
+func (r *TypesenseClusterReconciler) ReconcileConfigMap(ctx context.Context, ts tsv1alpha1.TypesenseCluster) (bool, error) {
 	r.logger.V(debugLevel).Info("reconciling config map")
 
 	configMapName := fmt.Sprintf(ClusterNodesConfigMap, ts.Name)
-	configMapExists := true
 	configMapObjectKey := client.ObjectKey{Namespace: ts.Namespace, Name: configMapName}
 
+	configMapExists := true
 	var cm = &v1.ConfigMap{}
-	if err = r.Get(ctx, configMapObjectKey, cm); err != nil {
+	if err := r.Get(ctx, configMapObjectKey, cm); err != nil {
 		if apierrors.IsNotFound(err) {
 			configMapExists = false
 		} else {
 			r.logger.Error(err, fmt.Sprintf("unable to fetch config map: %s", configMapName))
-			return ptr.To[bool](false), err
+			return false, err
 		}
 	}
 
+	var err error
+	updated := false
 	if !configMapExists {
 		r.logger.V(debugLevel).Info("creating config map", "configmap", configMapObjectKey.Name)
 
-		cm, err = r.createConfigMap(ctx, configMapObjectKey, &ts)
+		_, err := r.createConfigMap(ctx, configMapObjectKey, &ts)
 		if err != nil {
 			r.logger.Error(err, "creating config map failed", "configmap", configMapObjectKey.Name)
-			return nil, err
+			return false, err
 		}
 	} else {
 		r.logger.V(debugLevel).Info("updating config map", "configmap", configMapObjectKey.Name)
 
-		cm, _, err = r.updateConfigMap(ctx, &ts, cm, nil)
+		_, _, updated, err = r.updateConfigMap(ctx, &ts, cm, nil)
 		if err != nil {
-			return nil, err
+			return false, err
 		}
 	}
 
-	return &configMapExists, nil
+	return updated, nil
 }
 
 const nodeNameLenLimit = 64
@@ -81,7 +83,7 @@ func (r *TypesenseClusterReconciler) createConfigMap(ctx context.Context, key cl
 	return cm, nil
 }
 
-func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *tsv1alpha1.TypesenseCluster, cm *v1.ConfigMap, replicas *int32) (*v1.ConfigMap, int, error) {
+func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *tsv1alpha1.TypesenseCluster, cm *v1.ConfigMap, replicas *int32) (*v1.ConfigMap, int, bool, error) {
 	stsName := fmt.Sprintf(ClusterStatefulSet, ts.Name)
 	stsObjectKey := client.ObjectKey{
 		Name:      stsName,
@@ -93,13 +95,13 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 		if apierrors.IsNotFound(err) {
 			err := r.deleteConfigMap(ctx, cm)
 			if err != nil {
-				return nil, 0, err
+				return nil, 0, false, err
 			}
 		} else {
 			r.logger.Error(err, fmt.Sprintf("unable to fetch statefulset: %s", stsName))
 		}
 
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	if replicas == nil {
@@ -109,13 +111,13 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 	nodes, err := r.getNodes(ctx, ts, *replicas, false)
 	fallback, err := r.getNodes(ctx, ts, *replicas, true)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	availableNodes := len(nodes)
 	if availableNodes == 0 {
 		r.logger.V(debugLevel).Info("empty quorum configuration")
-		return nil, 0, fmt.Errorf("empty quorum configuration")
+		return nil, 0, false, fmt.Errorf("empty quorum configuration")
 	}
 
 	desired := cm.DeepCopy()
@@ -126,17 +128,19 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 
 	r.logger.V(debugLevel).Info("current quorum configuration", "size", availableNodes, "nodes", nodes)
 
+	updated := false
 	if cm.Data["nodes"] != desired.Data["nodes"] || cm.Data["fallback"] != desired.Data["fallback"] {
 		r.logger.Info("updating quorum configuration", "size", availableNodes, "nodes", nodes)
 
 		err := r.Update(ctx, desired)
 		if err != nil {
 			r.logger.Error(err, "updating quorum configuration failed")
-			return nil, 0, err
+			return nil, 0, false, err
 		}
+		updated = true
 	}
 
-	return desired, availableNodes, nil
+	return desired, availableNodes, updated, nil
 }
 
 func (r *TypesenseClusterReconciler) deleteConfigMap(ctx context.Context, cm *v1.ConfigMap) error {

--- a/internal/controller/typesensecluster_controller.go
+++ b/internal/controller/typesensecluster_controller.go
@@ -135,6 +135,11 @@ func (r *TypesenseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	if updated {
 		r.logger.Info("config map updated", "configmap", ts.Name)
+		err = r.ForcePodsConfigMapUpdate(ctx, &ts)
+		if err != nil {
+			r.logger.Error(err, "failed to force pods configmap update", "configmap", ts.Name)
+		}
+		// TODO: remove this if forced configmap update is working
 		r.logger.Info("requeueing to give cluster time to update", "configmap", ts.Name, "requeueAfter", configMapRequeuePeriod)
 		return ctrl.Result{RequeueAfter: configMapRequeuePeriod}, nil
 	}

--- a/internal/controller/typesensecluster_controller.go
+++ b/internal/controller/typesensecluster_controller.go
@@ -195,7 +195,7 @@ func (r *TypesenseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	cond := ConditionReasonQuorumStateUnknown
-	if updated {
+	if !updated {
 		condition, _, err := r.ReconcileQuorum(ctx, &ts, secret, client.ObjectKeyFromObject(sts))
 		if err != nil {
 			r.logger.Error(err, "reconciling quorum health failed")
@@ -247,7 +247,7 @@ func (r *TypesenseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	lastAction := "bootstrapping"
-	if updated {
+	if !updated {
 		lastAction = "reconciling"
 	}
 	requeueAfter = time.Duration(60+terminationGracePeriodSeconds) * time.Second

--- a/internal/controller/typesensecluster_helpers.go
+++ b/internal/controller/typesensecluster_helpers.go
@@ -2,8 +2,17 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"time"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/v1alpha1/forced-configmap-update-time"
 )
 
 func (r *TypesenseClusterReconciler) patchStatus(
@@ -20,5 +29,35 @@ func (r *TypesenseClusterReconciler) patchStatus(
 		return err
 	}
 
+	return nil
+}
+
+// ForcePodsConfigMapUpdate forces a configmap update for all pods in the statefulset
+// it should be called after a configmap update occurs
+// https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically
+func (r *TypesenseClusterReconciler) ForcePodsConfigMapUpdate(ctx context.Context, ts *tsv1alpha1.TypesenseCluster) error {
+	labelMap := make(map[string]string)
+	labelMap["app"] = fmt.Sprintf(ClusterAppLabel, ts.Name)
+	labelSelector := labels.SelectorFromSet(labelMap)
+
+	var podList v1.PodList
+	if err := r.Client.List(ctx, &podList,
+		client.InNamespace(ts.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
+		return err
+	}
+
+	var err error
+	for _, pod := range podList.Items {
+		pod.Annotations[ForceConfigMapUpdateAnnotation] = time.Now().Format(time.RFC3339)
+		err = r.Update(ctx, &pod)
+		if err != nil {
+			r.logger.Error(err, "failed to update pod metadata", "pod", pod.Name)
+		}
+	}
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/controller/typesensecluster_helpers.go
+++ b/internal/controller/typesensecluster_helpers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/v1alpha1/forced-configmap-update-time"
+	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/forced-configmap-update-time"
 )
 
 func (r *TypesenseClusterReconciler) patchStatus(

--- a/internal/controller/typesensecluster_quorum.go
+++ b/internal/controller/typesensecluster_quorum.go
@@ -216,7 +216,7 @@ func (r *TypesenseClusterReconciler) downgradeQuorum(
 		return ConditionReasonQuorumNotReady, 0, err
 	}
 
-	_, size, err := r.updateConfigMap(ctx, ts, cm, ptr.To[int32](desiredReplicas))
+	_, size, _, err := r.updateConfigMap(ctx, ts, cm, ptr.To[int32](desiredReplicas))
 	if err != nil {
 		return ConditionReasonQuorumNotReady, 0, err
 	}
@@ -246,7 +246,7 @@ func (r *TypesenseClusterReconciler) upgradeQuorum(
 		return ConditionReasonQuorumNotReady, 0, err
 	}
 
-	_, _, err = r.updateConfigMap(ctx, ts, cm, &size)
+	_, _, _, err = r.updateConfigMap(ctx, ts, cm, &size)
 	if err != nil {
 		return ConditionReasonQuorumNotReady, 0, err
 	}

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -99,7 +99,7 @@ func (r *TypesenseClusterReconciler) ReconcileStatefulSet(ctx context.Context, t
 					r.logger.V(debugLevel).Error(err, fmt.Sprintf("unable to fetch config map: %s", configMapName))
 				}
 
-				_, _, err = r.updateConfigMap(ctx, ts, cm, updatedSts.Spec.Replicas)
+				_, _, _, err = r.updateConfigMap(ctx, ts, cm, updatedSts.Spec.Replicas)
 				if err != nil {
 					r.logger.V(debugLevel).Error(err, fmt.Sprintf("unable to update config map: %s", configMapName))
 				}


### PR DESCRIPTION
This PR reworks when quorom is reconciled.

The main reasoning behind the changes is to avoid detecting quorum status and taking action while the most current list of pod IPs is still propagating to the pods. If the configmap updated... we must wait.

I discovered even brand-new/empty clusters get downgraded during updates (I was using simple cpu/memory spec changes) even though their pods start back up and join the cluster rather quickly. Watching logs indicated both existing pods and brand new ones weren't getting updated config maps.

This set of changes has stabilized both brand-new/empty clusters and the clusters I'm running in my staging environment with >20min startup/ready times (due to large amounts of data to load).